### PR TITLE
fix gsettings schema error on file picker dialog

### DIFF
--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -1,6 +1,6 @@
 { stdenv, makeDesktopItem, gcc, slippi-desktop, playbackSlippi, fetchFromGitHub, makeWrapper
 , mesa_drivers, mesa_glu, mesa, pkgconfig, cmake, bluez, ffmpeg, libao, libGLU
-, gtk2, gtk3, glib, glib-networking, gettext, xorg, readline, openal, libevdev, portaudio, libusb
+, gtk2, gtk3, wrapGAppsHook, glib, glib-networking, gettext, xorg, readline, openal, libevdev, portaudio, libusb
 , libpulseaudio, libudev, gnumake, wxGTK30, gdk-pixbuf, soundtouch, miniupnpc
 , mbedtls, curl, lzo, sfml, enet, xdg_utils, hidapi, webkit, vulkan-loader }:
 let
@@ -83,7 +83,7 @@ in stdenv.mkDerivation rec {
     ln -s ${netplay-desktop}/share/applications $out/share
   '';
 
-  nativeBuildInputs = [ pkgconfig cmake ];
+  nativeBuildInputs = [ pkgconfig cmake wrapGAppsHook ];
   buildInputs = [
     vulkan-loader
     makeWrapper

--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -59,7 +59,6 @@ in stdenv.mkDerivation rec {
       rm -rf ../Data/Sys/GameSettings
       cp -r "${slippi-desktop}/app/dolphin-dev/overwrite/Sys/GameSettings" ../Data/Sys
     '' + ''
-      touch Binaries/portable.txt
       cp -r -n ../Data/Sys/ Binaries/
       cp -r Binaries/ $out
       mkdir -p $out/bin
@@ -69,16 +68,14 @@ in stdenv.mkDerivation rec {
     wrapProgram "$out/dolphin-emu" \
       --set "GDK_BACKEND" "x11" \
       --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
-      --prefix LD_LIBRARY_PATH : "${vulkan-loader}/lib" \
-      --add-flags '-u $HOME/.config/slippi-playback'
+      --prefix LD_LIBRARY_PATH : "${vulkan-loader}/lib"
     ln -s $out/dolphin-emu $out/bin/slippi-playback
     ln -s ${playback-desktop}/share/applications $out/share
   '' else ''
     wrapProgram "$out/dolphin-emu" \
       --set "GDK_BACKEND" "x11" \
       --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules" \
-      --prefix LD_LIBRARY_PATH : "${vulkan-loader}/lib" \
-      --add-flags '-u $HOME/.config/slippi-netplay'
+      --prefix LD_LIBRARY_PATH : "${vulkan-loader}/lib"
     ln -s $out/dolphin-emu $out/bin/slippi-netplay
     ln -s ${netplay-desktop}/share/applications $out/share
   '';


### PR DESCRIPTION
currently, opening the file picker dialog in `slippi-netplay` errors out with "no gsettings schemas found." By wrapping it with wrapGAppsHook, the path to the schemas are correctly added to the XDG_DATA_DIRS environment variable.