### PR TITLE
slippi: 2.2.6 -> 2.3.0

### DIFF
--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -27,14 +27,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "slippi-ishiiruka";
-  version = "2.2.6";
+  version = "2.3.0";
   name =
     "${pname}-${version}-${if playbackSlippi then "playback" else "netplay"}";
   src = fetchFromGitHub {
     owner = "project-slippi";
     repo = "Ishiiruka";
     rev = "v${version}";
-    sha256 = "sha256-c+lfctDIl6HK3nBfNiARkiHudJSxpgHpWCu98RyaptY=";
+    sha256 = "1iag50w743q3469w3aacij6m7mcf20g527nl4vv0wyfq5vwpmipn";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
`2.2.6` -> `2.3.0`: 
* https://twitter.com/Fizzi36/status/1389046132534218752
* https://github.com/project-slippi/Ishiiruka/releases/tag/v2.3.0
