### PR TITLE
slippi: 2.3.3 -> 2.4.0

### DIFF
--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -27,14 +27,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "slippi-ishiiruka";
-  version = "2.3.3";
+  version = "2.4.0";
   name =
     "${pname}-${version}-${if playbackSlippi then "playback" else "netplay"}";
   src = fetchFromGitHub {
     owner = "project-slippi";
     repo = "Ishiiruka";
     rev = "v${version}";
-    sha256 = "1vkmppzclhd6cam06g870ds382cjm2ivm2fxwk2xam9dqkks92gi";
+    sha256 = "1gzwf2hc2nqrij6drlzfy0s9zvd2arqdpz2wsld1vrgz25bqhm9j";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
https://github.com/project-slippi/Ishiiruka/releases/tag/v2.4.0