### PR TITLE
nixpkgs update 20.09 -> 22.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "lowdown-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1598695561,
-        "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
         "owner": "kristapsdz",
         "repo": "lowdown",
-        "rev": "1705b4a26fbf065d9574dce47a94e8c7c79e052f",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
         "type": "github"
       },
       "original": {
@@ -19,14 +19,15 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1609520816,
-        "narHash": "sha256-IGO7tfJXsv9u2wpW76VCzOsHYapRZqH9pHGVsoffPrI=",
+        "lastModified": 1654930096,
+        "narHash": "sha256-EpXxh+AfK3S80igRDMxpMd/eFBcnFUb2AzJIxy7Fl+I=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "8a2ce0f455da32bc20978e68c0aad9efb4560abc",
+        "rev": "37fc4d73bbf4bd09f20530420b1511b9b1793a2d",
         "type": "github"
       },
       "original": {
@@ -36,31 +37,48 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1602702596,
-        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
+        "lastModified": 1653988320,
+        "narHash": "sha256-ZaqFFsSDipZ6KVqriwM34T739+KLYJvNmCWzErjAg7c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
+        "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-20.09-small",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1611413872,
-        "narHash": "sha256-nD9e3f9P+YQ1qDSHdRXIAor40eqANBv1o03zGvpJsnM=",
+        "lastModified": 1654847188,
+        "narHash": "sha256-MC+eP7XOGE1LAswOPqdcGoUqY9mEQ3ZaaxamVTbc0hM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe08be60cb84148a3dba29cfdb090fa185cacdaa",
+        "rev": "8b66e3f2ebcc644b78cec9d6f152192f4e7d322f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-20.09",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -75,11 +93,11 @@
     "slippi-desktop": {
       "flake": false,
       "locked": {
-        "lastModified": 1607036060,
-        "narHash": "sha256-TUYsiVvKAws3N3roZYDwkLB0obyl6zwvh8CAk2RwHrY=",
+        "lastModified": 1654584458,
+        "narHash": "sha256-+EjwK1y3gfjWKUA50k1UP5CV4AkjRmqabYHKaEmR90M=",
         "owner": "project-slippi",
         "repo": "slippi-desktop-app",
-        "rev": "3ca39ba6bbd02157515b12a79aa01e5d669ad1b1",
+        "rev": "ccee54118f5ccfd5a60f55de5f345dd9b2d5deea",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-20.09";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
     slippi-desktop.url = "github:project-slippi/slippi-desktop-app";
     slippi-desktop.flake = false;
   };

--- a/pplus/slippi.nix
+++ b/pplus/slippi.nix
@@ -1,8 +1,8 @@
 { stdenv, gcc, fetchFromGitHub
 , mesa_drivers, mesa_glu, mesa, pkgconfig, cmake, bluez, ffmpeg, libao, libGLU
 , gtk2, gtk3, glib, gettext, xorg, readline, openal, libevdev, portaudio, libusb
-, libpulseaudio, libudev, gnumake, wxGTK30, gdk-pixbuf, soundtouch, miniupnpc
-, mbedtls, curl, lzo, sfml, enet, xdg_utils, hidapi, webkit
+, libpulseaudio, udev, gnumake, wxGTK30, gdk-pixbuf, soundtouch, miniupnpc
+, mbedtls, curl, lzo, sfml, enet, xdg_utils, hidapi, webkitgtk
 , projectplus-sdcard, projectplus-config, tree }:
 stdenv.mkDerivation rec {
 
@@ -80,7 +80,7 @@ stdenv.mkDerivation rec {
     portaudio
     libusb
     libpulseaudio
-    libudev
+    udev
     gnumake
     wxGTK30
     gtk2
@@ -95,7 +95,7 @@ stdenv.mkDerivation rec {
     enet
     xdg_utils
     hidapi
-    webkit
+    webkitgtk
     projectplus-sdcard
     projectplus-config
     tree

--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -1,8 +1,8 @@
 { stdenv, lib, makeDesktopItem, gcc, slippi-desktop, playbackSlippi, fetchFromGitHub, makeWrapper
 , mesa_drivers, mesa_glu, mesa, pkgconfig, cmake, bluez, ffmpeg, libao, libGLU
 , gtk2, gtk3, wrapGAppsHook, glib, glib-networking, gettext, xorg, readline, openal, libevdev, portaudio, libusb
-, libpulseaudio, libudev, gnumake, wxGTK30, gdk-pixbuf, soundtouch, miniupnpc
-, mbedtls, curl, lzo, sfml, enet, xdg_utils, hidapi, webkit, vulkan-loader }:
+, libpulseaudio, udev, gnumake, wxGTK30, gdk-pixbuf, soundtouch, miniupnpc
+, mbedtls, curl, lzo, sfml, enet, xdg_utils, hidapi, webkitgtk, vulkan-loader }:
 let
 
   netplay-desktop = makeDesktopItem {
@@ -11,8 +11,8 @@ let
     comment = "Play Melee Online!";
     desktopName = "Slippi-Netplay";
     genericName = "Wii/GameCube Emulator";
-    categories = "Game;Emulator;";
-    startupNotify = "false";
+    categories = [ "Game" "Emulator" ];
+    startupNotify = false;
   };
 
   playback-desktop = makeDesktopItem {
@@ -21,8 +21,8 @@ let
     comment = "Watch Your Slippi Replays";
     desktopName = "Slippi-Playback";
     genericName = "Wii/GameCube Emulator";
-    categories = "Game;Emulator;";
-    startupNotify = "false";
+    categories = [ "Game" "Emulator" ];
+    startupNotify = false;
   };
 
 in stdenv.mkDerivation rec {
@@ -109,7 +109,7 @@ in stdenv.mkDerivation rec {
     portaudio
     libusb
     libpulseaudio
-    libudev
+    udev
     gnumake
     wxGTK30
     gtk2
@@ -124,6 +124,6 @@ in stdenv.mkDerivation rec {
     enet
     xdg_utils
     hidapi
-    webkit
+    webkitgtk
   ];
 }


### PR DESCRIPTION
nixos doesn't do LTS stable versions like Ubuntu so it's inappropriate to be using an old version as a base. With the update to 22.05 this flake stopped working. This fork bumps the internal nixpkgs version to 22.05 and makes necessary changes to the nix expressions for the update. Changes:

- bump nixpkgs 20.09 -> 22.05
- changes to makeDesktopItem format
- nixpkgs 22.05 package renames:
  - libudev -> udev
  - webkit -> webkitgtk