### PR TITLE
slippi: 2.4.0 -> 2.5.1

### DIFF
--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -27,14 +27,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "slippi-ishiiruka";
-  version = "2.4.0";
+  version = "2.5.1";
   name =
     "${pname}-${version}-${if playbackSlippi then "playback" else "netplay"}";
   src = fetchFromGitHub {
     owner = "project-slippi";
     repo = "Ishiiruka";
     rev = "v${version}";
-    sha256 = "1gzwf2hc2nqrij6drlzfy0s9zvd2arqdpz2wsld1vrgz25bqhm9j";
+    sha256 = "1ha3hv2lnmjhqn3vhbca6vm3l2p2v0mp94n1lgrvjfrn827g2kbx";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
https://github.com/project-slippi/Ishiiruka/releases/tag/v2.5.1