### PR TITLE
slippi: 2.5.1 -> 2.5.2

### DIFF
--- a/slippi/default.nix
+++ b/slippi/default.nix
@@ -27,14 +27,14 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "slippi-ishiiruka";
-  version = "2.5.1";
+  version = "2.5.2";
   name =
     "${pname}-${version}-${if playbackSlippi then "playback" else "netplay"}";
   src = fetchFromGitHub {
     owner = "project-slippi";
     repo = "Ishiiruka";
     rev = "v${version}";
-    sha256 = "1ha3hv2lnmjhqn3vhbca6vm3l2p2v0mp94n1lgrvjfrn827g2kbx";
+    sha256 = "0wzcwf6q84xx08y5fqiwch4q3sjac85fsjvv9pjzk8263z1q7adw";
   };
 
   outputs = [ "out" ];


### PR DESCRIPTION
https://github.com/djanatyn/ssbm-nix/compare/slippi/2.5.2