### PR TITLE
slippi: 3.0.3 -> 3.2.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,11 +51,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665259268,
-        "narHash": "sha256-ONFhHBLv5nZKhwV/F2GOH16197PbvpyWhoO0AOyktkU=",
+        "lastModified": 1692447944,
+        "narHash": "sha256-fkJGNjEmTPvqBs215EQU4r9ivecV5Qge5cF/QDLVn3U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5924154f000e6306030300592f4282949b2db6c",
+        "rev": "d680ded26da5cf104dd2735a51e88d2d8f487b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates slippi to the latest version. I had to make a few changes to get it to compile:

- They added a Rust submodule to `slippi-ishiiruka` so I had to make changes accordingly.
- Updated nixpkgs
- Replace `mbedtls` with `mbedtls_2`
- Replace `wxGTK30` with `wxGTK32` (Also resolves #37)
- Make some changes to the CMake flags.