### PR TITLE
slippi-launcher: init at 2.10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,18 @@ Goals:
 * Build common training mods (UnclePunch, 20XX Hack Pack)
 
 # Playing Slippi Online!
+## With `slippi-netplay` directly
 Run `slippi-netplay` or the desktop entry.
+
+## With `slippi-launcher`
+Add the following to your Home Manager config:
+```nix
+ssbm.slippi-launcher= {
+  enable = true;
+  # Replace with the path to your Melee ISO
+  isoPath = "Path/To/SSBM.ciso";
+};
+```
 
 # FAQ
 ## How do I enable the GCC overclock adapter?

--- a/flake.nix
+++ b/flake.nix
@@ -98,5 +98,78 @@
             environment.systemPackages = [ (mkIf cfg.keyb0xx.enable (pkgs.keyb0xx.override { keyb0xxconfig = cfg.keyb0xx.config; })) ];
           };
         };
+      homeManagerModule = { pkgs, config, ... }:
+        let
+          cfg = config.ssbm;
+        in
+        with nixpkgs.lib; {
+          options.ssbm = {
+            slippi-launcher = {
+              enable = mkEnableOption "Install Slippi Launcher";
+              # Game settings
+              isoPath = mkOption {
+                default = "";
+                type = types.str;
+                description = "The path to an NTSC Melee ISO.";
+              };
+              launchMeleeOnPlay = mkEnableOption "Launch Melee in Dolphin when the Play button is pressed." // { default = true; };
+              enableJukebox = mkEnableOption "Enable in-game music via Slippi Jukebox. Incompatible with WASAPI." // { default = true; };
+              # Replay settings
+              rootSlpPath = mkOption {
+                default = "${config.home.homeDirectory}/Slippi";
+                type = types.str;
+                description = "The folder where your SLP replays should be saved.";
+              };
+              useMonthlySubfolders = mkEnableOption "Save replays to monthly subfolders";
+              spectateSlpPath = mkOption {
+                default = "${cfg.slippi-launcher.rootSlpPath}/Spectate";
+                type = types.nullOr types.str;
+                description = "The folder where spectated games should be saved.";
+              };
+              extraSlpPaths = mkOption {
+                default = [ ];
+                type = types.listOf types.str;
+                description = "Choose any additional SLP directories that should show up in the replay browser.";
+              };
+              # Netplay
+              netplayDolphinPath = mkOption {
+                default = "${pkgs.slippi-netplay}";
+                type = types.str;
+                description = "The path to the folder containing the Netplay Dolphin Executable";
+              };
+              # Playback
+              playbackDolphinPath = mkOption {
+                default = "${pkgs.slippi-playback}";
+                type = types.str;
+                description = "The path to the folder containing the Playback Dolphin Executable";
+              };
+            };
+          };
+          config = {
+            home.packages = [ (mkIf cfg.slippi-launcher.enable pkgs.slippi-launcher) ];
+            xdg.configFile."Slippi Launcher/Settings".source =
+              let
+                jsonFormat = pkgs.formats.json { };
+              in
+              jsonFormat.generate "slippi-config" {
+                settings = {
+                  isoPath = cfg.slippi-launcher.isoPath;
+                  launchMeleeOnPlay = cfg.slippi-launcher.launchMeleeOnPlay;
+                  enableJukebox = cfg.slippi-launcher.enableJukebox;
+                  # Replay settings
+                  rootSlpPath = cfg.slippi-launcher.rootSlpPath;
+                  useMonthlySubfolders = cfg.slippi-launcher.useMonthlySubfolders;
+                  spectateSlpPath = cfg.slippi-launcher.spectateSlpPath;
+                  extraSlpPaths = cfg.slippi-launcher.extraSlpPaths;
+                  # Netplay
+                  netplayDolphinPath = cfg.slippi-launcher.netplayDolphinPath;
+                  # Playback
+                  playbackDolphinPath = cfg.slippi-launcher.playbackDolphinPath;
+                  # Advanced settings
+                  autoUpdateLauncher = false;
+                };
+              };
+          };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,91 +9,94 @@
   description = "Nix expressions for Super Smash Bros. Melee players.";
 
   outputs = { self, nixpkgs, nix, slippi-desktop, ... }@inputs:
-  let
-
-    supportedSystems = [ "x86_64-linux" ];
-    forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
-
-  in {
-
-    overlay = final: prev: import ./overlay.nix { inherit slippi-desktop final prev; };
-
-    apps = forAllSystems (system: let
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [ self.overlay ];
-      };
-    in {
-      slippi-netplay = {
-        type = "app";
-        program = "${pkgs.slippi-netplay}/bin/slippi-netplay";
-      };
-      slippi-playback = {
-        type = "app";
-        program = "${pkgs.slippi-playback}/bin/slippi-playback";
-      };
-    });
-
-    packages = forAllSystems (system: let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ self.overlay ];
-        };
-      in {
-        wiimms-iso-tools = pkgs.wiimms-iso-tools;
-        slippi-netplay = pkgs.slippi-netplay;
-        slippi-playback = pkgs.slippi-playback;
-        gecko = pkgs.gecko;
-        powerpc-eabi-assembling = pkgs.powerpc-eabi-assembling;
-        slippi-netplay-chat-edition = pkgs.slippi-netplay-chat-edition;
-        gcmtool = pkgs.gcmtool;
-        projectplus-sdcard = pkgs.projectplus-sdcard;
-        projectplus-config = pkgs.projectplus-config;
-        keyb0xx = pkgs.keyb0xx;
-        /* dat-texture-wizard = pkgs.dat-texture-wizard; */
-    });
-
-    nixosModule = { pkgs, config, ... }:
     let
-      cfg = config.ssbm;
-    in with nixpkgs.lib; {
 
-      options.ssbm = {
-        overlay.enable = mkEnableOption "Activate the package overlay.";
-        cache.enable = mkEnableOption "Turn on cache.";
-        gcc.oc-kmod.enable = mkEnableOption "Turn on overclocking kernel module.";
-        gcc.rules.enable = mkEnableOption "Turn on rules for your gamecube controller adapter.";
-        gcc.rules.rules = mkOption {
-          default = readFile ./gcc.rules;
-          type = types.lines;
-          description = "To be appended to services.udev.extraRules if gcc.rules.enable is set.";
-        };
-        keyb0xx = {
-          enable = mkEnableOption "Add keyb0xx to your binary path";
-          config = mkOption {
-            default = readFile ./keyb0xx/config.h;
-            type = types.lines;
-            description = "Config.h file to compile keyb0xx with.";
+      supportedSystems = [ "x86_64-linux" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+
+    in
+    {
+
+      overlay = final: prev: import ./overlay.nix { inherit slippi-desktop final prev; };
+
+      apps = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        {
+          slippi-netplay = {
+            type = "app";
+            program = "${pkgs.slippi-netplay}/bin/slippi-netplay";
+          };
+          slippi-playback = {
+            type = "app";
+            program = "${pkgs.slippi-playback}/bin/slippi-playback";
+          };
+        });
+
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlay ];
+          };
+        in
+        {
+          wiimms-iso-tools = pkgs.wiimms-iso-tools;
+          slippi-netplay = pkgs.slippi-netplay;
+          slippi-playback = pkgs.slippi-playback;
+          slippi-launcher = pkgs.slippi-launcher;
+          gecko = pkgs.gecko;
+          powerpc-eabi-assembling = pkgs.powerpc-eabi-assembling;
+          slippi-netplay-chat-edition = pkgs.slippi-netplay-chat-edition;
+          gcmtool = pkgs.gcmtool;
+          projectplus-sdcard = pkgs.projectplus-sdcard;
+          projectplus-config = pkgs.projectplus-config;
+          keyb0xx = pkgs.keyb0xx;
+          /* dat-texture-wizard = pkgs.dat-texture-wizard; */
+        });
+
+      nixosModule = { pkgs, config, ... }:
+        let
+          cfg = config.ssbm;
+        in
+        with nixpkgs.lib; {
+
+          options.ssbm = {
+            overlay.enable = mkEnableOption "Activate the package overlay.";
+            cache.enable = mkEnableOption "Turn on cache.";
+            gcc.oc-kmod.enable = mkEnableOption "Turn on overclocking kernel module.";
+            gcc.rules.enable = mkEnableOption "Turn on rules for your gamecube controller adapter.";
+            gcc.rules.rules = mkOption {
+              default = readFile ./gcc.rules;
+              type = types.lines;
+              description = "To be appended to services.udev.extraRules if gcc.rules.enable is set.";
+            };
+            keyb0xx = {
+              enable = mkEnableOption "Add keyb0xx to your binary path";
+              config = mkOption {
+                default = readFile ./keyb0xx/config.h;
+                type = types.lines;
+                description = "Config.h file to compile keyb0xx with.";
+              };
+            };
+          };
+          config = {
+            nixpkgs.overlays = [ (mkIf cfg.overlay.enable self.overlay) ];
+            services.udev.extraRules = mkIf cfg.gcc.rules.enable cfg.gcc.rules.rules;
+            boot.kernelModules = mkIf cfg.gcc.oc-kmod.enable [ "gcadapter_oc" ];
+            boot.extraModulePackages = mkIf cfg.gcc.oc-kmod.enable [
+              config.boot.kernelPackages.gcadapter-oc-kmod
+            ];
+            nix = mkIf cfg.cache.enable {
+              settings.substituters = [ "https://ssbm-nix.cachix.org" ];
+              settings.trusted-public-keys = [ "ssbm-nix.cachix.org-1:YN104LKAWaKQIecOphkftXgXlYZVK/IRHM1UD7WAIew=" ];
+            };
+            environment.systemPackages = [ (mkIf cfg.keyb0xx.enable (pkgs.keyb0xx.override { keyb0xxconfig = cfg.keyb0xx.config; })) ];
           };
         };
-      };
-      config = {
-        nixpkgs.overlays = [ (mkIf cfg.overlay.enable self.overlay) ];
-        services.udev.extraRules = mkIf cfg.gcc.rules.enable cfg.gcc.rules.rules;
-        boot.kernelModules = mkIf cfg.gcc.oc-kmod.enable ["gcadapter_oc"];
-        boot.extraModulePackages = mkIf cfg.gcc.oc-kmod.enable [
-          config.boot.kernelPackages.gcadapter-oc-kmod
-        ];
-        nix = mkIf cfg.cache.enable {
-          settings.substituters = [ "https://ssbm-nix.cachix.org" ];
-          settings.trusted-public-keys = [ "ssbm-nix.cachix.org-1:YN104LKAWaKQIecOphkftXgXlYZVK/IRHM1UD7WAIew=" ];
-        };
-        environment.systemPackages = [ (mkIf cfg.keyb0xx.enable (pkgs.keyb0xx.override { keyb0xxconfig = cfg.keyb0xx.config; })) ];
-      };
-
     };
-
-  };
-
 }
-

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,7 @@
 { slippi-desktop
 , final
-, prev }:
+, prev
+}:
 
 with final.pkgs; rec {
 
@@ -17,7 +18,8 @@ with final.pkgs; rec {
 
   slippi-netplay = callPackage ./slippi {
     inherit slippi-desktop;
-    playbackSlippi = false; };
+    playbackSlippi = false;
+  };
 
   slippi-netplay-chat-edition = slippi-netplay.overrideAttrs (oldAttrs: rec {
     pname = "slippi-ishiiruka-chat";
@@ -31,6 +33,8 @@ with final.pkgs; rec {
       sha256 = "1rd449s00dqmngp3mrapg91k4hhg2kyc0kizc37vb4l2zswpkqah";
     };
   });
+
+  slippi-launcher = callPackage ./slippi-launcher { };
 
   gcmtool = callPackage ./gcmtool { };
 

--- a/slippi-launcher/default.nix
+++ b/slippi-launcher/default.nix
@@ -3,6 +3,7 @@
 , fetchurl
 , makeDesktopItem
 , copyDesktopItems
+, makeWrapper
 }:
 
 stdenvNoCC.mkDerivation rec {
@@ -16,6 +17,7 @@ stdenvNoCC.mkDerivation rec {
       url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
       hash = "sha256-zYxSVbxERLtz5/9IS8PUft6ZQw6kQtSUp0/KmmA/bmM=";
     };
+
     extraInstallCommands = ''
       source "${makeWrapper}/nix-support/setup-hook"
       wrapProgram $out/bin/slippi-launcher-${version} \

--- a/slippi-launcher/default.nix
+++ b/slippi-launcher/default.nix
@@ -1,0 +1,49 @@
+{ stdenvNoCC
+, appimageTools
+, fetchurl
+, makeDesktopItem
+, copyDesktopItems
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "slippi-launcher";
+  version = "2.10.5";
+
+  src = appimageTools.wrapType2 rec {
+    inherit pname version;
+
+    src = fetchurl {
+      url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
+      hash = "sha256-zYxSVbxERLtz5/9IS8PUft6ZQw6kQtSUp0/KmmA/bmM=";
+    };
+    extraInstallCommands = ''
+      source "${makeWrapper}/nix-support/setup-hook"
+      wrapProgram $out/bin/slippi-launcher-${version} \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+    '';
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "slippi-launcher";
+      exec = "slippi-launcher-${version}";
+      icon = "slippi-launcher";
+      desktopName = "Slippi Launcher";
+      comment = "The way to play Slippi Online and watch replays";
+      type = "Application";
+      categories = [ "Game" ];
+      keywords = [ "slippi" "melee" "rollback" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    cp -r "$src/bin" "$out"
+
+    runHook postInstall
+  '';
+
+  nativeBuildInputs = [ copyDesktopItems ];
+}


### PR DESCRIPTION
Adds a package for the [Slippi launcher](https://github.com/project-slippi/slippi-launcher).

I tried building it from source with yarn, but I ended up wrapping an appimage instead because for some reason it needed to modify the yarn dependencies and I could not figure out how to work around that otherwise.

I took the liberty of adding a Home Manager module in order to declaratively configure Slippi to use the `slippi-netplay` and `slippi-playback` packages instead of the versions it usually downloads and updates itself, which do not work in NixOS anyways. I added the other settings so that users would not be locked out of configuring them, as they are stored in the same file as the netplay and playback directory settings.

~~I also went ahead and fixed #36. But if you would prefer, I could put that in a separate pull request instead.~~ Removed since #42 got to it.